### PR TITLE
서비스에서 이용할 프로필 사진 등록(구글 계정 프로필 이미지 -> 등록한 이미지로의 수정)

### DIFF
--- a/src/main/java/com/example/want/api/member/controller/MemberController.java
+++ b/src/main/java/com/example/want/api/member/controller/MemberController.java
@@ -3,8 +3,10 @@ package com.example.want.api.member.controller;
 import com.example.want.api.member.domain.Member;
 import com.example.want.api.member.dto.AcceptInvitationDto;
 import com.example.want.api.member.dto.GetInvitationDto;
+import com.example.want.api.member.dto.ProfileImageRqDto;
 import com.example.want.api.member.login.UserInfo;
 import com.example.want.api.member.service.MemberService;
+import com.example.want.common.CommonResDto;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -46,5 +48,12 @@ public class MemberController {
         String email = userInfo.getEmail();
         memberService.acceptInvitation(email, dto.getProjectId());
         return new ResponseEntity<>("Invitation accepted successfully.", HttpStatus.OK);
+    }
+
+    @PatchMapping("/profile/image")
+    public ResponseEntity<?> updateProfileImage(@AuthenticationPrincipal UserInfo userInfo,
+                                                @RequestBody ProfileImageRqDto profileImageRqDto) {
+        Member updatedMember = memberService.updateProfileImage(userInfo.getEmail(), profileImageRqDto);
+        return new ResponseEntity<>(new CommonResDto(HttpStatus.OK, "Success", updatedMember.getProfileUrl()), HttpStatus.OK);
     }
 }

--- a/src/main/java/com/example/want/api/member/domain/Member.java
+++ b/src/main/java/com/example/want/api/member/domain/Member.java
@@ -32,4 +32,10 @@ public class Member{
         this.profileUrl = userInfo.getProfileImageUrl();
         this.role = Role.MEMBER;
     }
+
+    public void updateProfileImage(String profileUrl) {
+        this.profileUrl = profileUrl;
+    }
+
+
 }

--- a/src/main/java/com/example/want/api/member/dto/ProfileImageRqDto.java
+++ b/src/main/java/com/example/want/api/member/dto/ProfileImageRqDto.java
@@ -1,0 +1,12 @@
+package com.example.want.api.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class ProfileImageRqDto {
+    private String profileUrl;
+}

--- a/src/main/java/com/example/want/api/member/service/MemberService.java
+++ b/src/main/java/com/example/want/api/member/service/MemberService.java
@@ -2,6 +2,7 @@ package com.example.want.api.member.service;
 
 import com.example.want.api.member.domain.Member;
 import com.example.want.api.member.dto.GetInvitationDto;
+import com.example.want.api.member.dto.ProfileImageRqDto;
 import com.example.want.api.member.repository.MemberRepository;
 import com.example.want.api.project.domain.Project;
 import com.example.want.api.project.repository.ProjectRepository;
@@ -73,5 +74,13 @@ public class MemberService {
 
         projectMember.setInvitationAccepted("Y");
         projectMemberRepository.save(projectMember);
+    }
+
+    // 구글 로그인 시 구글 프로필 사진이 프로필 이미지가 됨 -> 우리 서비스에서만 이용할 프로필 사진을 등록하는 건 결국 "수정"이 됨.
+    public Member updateProfileImage(String email, ProfileImageRqDto profileImageRqDto) {
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new RuntimeException("Member not found"));
+        member.updateProfileImage(profileImageRqDto.getProfileUrl());
+        return memberRepository.save(member);
     }
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
-[✔️] 기능 추가

### 반영 브랜치
ex) feat/memberProfileImage -> main

### 변경 사항
구글 로그인 시 구글 프로필 사진이 프로필 이미지가 됨 -> 우리 서비스에서만 이용할 프로필 사진을 등록하는 건 결국 "수정"이 됨.
=> @Patch 프로필 이미지 _ url String 수정으로 우선 구현

### 테스트 결과
<img width="297" alt="스크린샷 2024-07-30 오후 8 47 13" src="https://github.com/user-attachments/assets/6aeddffd-bc58-475d-ae17-7404d30a9797">

