### PR TITLE
초대 기능 수정 초대 보낸 사람 이름 표시

### DIFF
--- a/src/main/java/com/example/want/api/member/dto/InvitationResDto.java
+++ b/src/main/java/com/example/want/api/member/dto/InvitationResDto.java
@@ -22,6 +22,7 @@ public class InvitationResDto {
     private LocalDateTime createdTime;
     private String startTravel;
     private String endTravel;
+    private String inviterName;
     // todo 여행 장소 추가
     private List<ProjectDetailRsDto.ProjectStateList> projectStates;
 }

--- a/src/main/java/com/example/want/api/member/service/MemberService.java
+++ b/src/main/java/com/example/want/api/member/service/MemberService.java
@@ -47,6 +47,8 @@ public class MemberService {
             Project project = projectRepository.findById(projectMember.getProject().getId())
                     .orElseThrow(() -> new EntityNotFoundException("Project Not found"));
 
+            String inviterName = projectMember.getInviterName();
+
             InvitationResDto invitationResDto = InvitationResDto.builder()
                     .projectId(project.getId())
                     .projectTitle(project.getTitle())
@@ -62,6 +64,7 @@ public class MemberService {
                                     .city(projectState.getState().getCity())
                                     .build())
                             .collect(Collectors.toList()))
+                    .inviterName(inviterName)
                     .build();
             invitationResDtos.add(invitationResDto);
         }

--- a/src/main/java/com/example/want/api/project/dto/InvitationDto.java
+++ b/src/main/java/com/example/want/api/project/dto/InvitationDto.java
@@ -11,5 +11,6 @@ import lombok.NoArgsConstructor;
 @Builder
 public class InvitationDto {
     private Long projectId;
-    private String email;
+    private String email;  // 초대 받는 사람의 이메일
+    private String inviterName;  // 초대 보내는 사람의 이름
 }

--- a/src/main/java/com/example/want/api/project/service/ProjectService.java
+++ b/src/main/java/com/example/want/api/project/service/ProjectService.java
@@ -149,7 +149,8 @@ public class ProjectService {
                 .project(project)
                 .member(otherMember)
                 .authority(Authority.MEMBER)
-                .invitationAccepted("N") // 초대 수락을 하면 "Y"로 변경
+                .invitationAccepted("N")
+                .inviterName(member.getName())// 초대 수락을 하면 "Y"로 변경
                 .build();
 
         projectMemberRepository.save(projectMember);

--- a/src/main/java/com/example/want/api/projectMember/domain/ProjectMember.java
+++ b/src/main/java/com/example/want/api/projectMember/domain/ProjectMember.java
@@ -39,6 +39,8 @@ public class ProjectMember extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private Authority authority;
 
+    private String inviterName;
+
     public void updateIsExist(String isExist) {
         this.isExist = isExist;
     }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
-[] 기능 추가

### 반영 브랜치
ex) Fix/InviteMembers -> main

### 변경 사항
초대 요청을 보낼 시 보내는 사람의 이름을 같이 보내게 하였고
초대 요청을 확인 할 때에도 이름이 포함되게 하였습니다.

### 테스트 결과